### PR TITLE
Changed cache to false by default

### DIFF
--- a/pysphere/vi_server.py
+++ b/pysphere/vi_server.py
@@ -826,7 +826,7 @@ class VIServer:
 
     #---- DEPRECATED METHODS ----#
 
-    def _get_clusters(self, from_cache=True):
+    def _get_clusters(self, from_cache=False):
         """DEPRECATED: use get_clusters instead."""
         import warnings
         from exceptions import DeprecationWarning
@@ -837,7 +837,7 @@ class VIServer:
         ret = self.get_clusters()
         return dict([(v,k) for k,v in ret.iteritems()])
 
-    def _get_datacenters(self, from_cache=True):
+    def _get_datacenters(self, from_cache=False):
         """DEPRECATED: use get_datacenters instead."""
         import warnings
         from exceptions import DeprecationWarning
@@ -848,7 +848,7 @@ class VIServer:
         ret = self.get_datacenters()
         return dict([(v,k) for k,v in ret.iteritems()])
 
-    def _get_resource_pools(self, from_cache=True):
+    def _get_resource_pools(self, from_cache=False):
         """DEPRECATED: use get_resource_pools instead."""
         import warnings
         from exceptions import DeprecationWarning


### PR DESCRIPTION
Using a from_cache=True setting for clusters, datacenters, and resource pools causes issues when using multiple vcenter hosts, or when using multiple standalone esxi hosts. I expect the performance impact to be minimal, but I don't have a large cluster to test this against.